### PR TITLE
Add testing coverage to #9572

### DIFF
--- a/src/VisualizationTests/HelixWatch3DViewModelTests.cs
+++ b/src/VisualizationTests/HelixWatch3DViewModelTests.cs
@@ -821,19 +821,25 @@ namespace WpfVisualizationTests
             // 5 points for point0 node, 2 points for point1 and point2 node
             Assert.AreEqual(9, BackgroundPreviewGeometry.TotalPoints());
 
-            // Modify lacing strategy
+            // Modify lacing strategy to Longest
             ViewModel.CurrentSpaceViewModel.SelectAllCommand.Execute(null);
             ViewModel.CurrentSpaceViewModel.SetArgumentLacingCommand.Execute(LacingStrategy.Longest.ToString());
 
             Assert.AreEqual(12, BackgroundPreviewGeometry.TotalPoints());
 
-            // Modify lacing strategy again
+            // Modify lacing strategy to Auto
+            ViewModel.CurrentSpaceViewModel.SelectAllCommand.Execute(null);
+            ViewModel.CurrentSpaceViewModel.SetArgumentLacingCommand.Execute(LacingStrategy.Auto.ToString());
+
+            Assert.AreEqual(9, BackgroundPreviewGeometry.TotalPoints());
+
+            // Modify lacing strategy to CrossProduct
             ViewModel.CurrentSpaceViewModel.SelectAllCommand.Execute(null);
             ViewModel.CurrentSpaceViewModel.SetArgumentLacingCommand.Execute(LacingStrategy.CrossProduct.ToString());
 
             Assert.AreEqual(17, BackgroundPreviewGeometry.TotalPoints());
 
-            // Change lacing back to original state
+            // Change lacing back to Shortest
             ViewModel.CurrentSpaceViewModel.SelectAllCommand.Execute(null);
             ViewModel.CurrentSpaceViewModel.SetArgumentLacingCommand.Execute(LacingStrategy.Shortest.ToString());
             Assert.AreEqual(9, BackgroundPreviewGeometry.TotalPoints());

--- a/test/DynamoCoreWpfTests/WorkspaceGeneralOperations.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceGeneralOperations.cs
@@ -1,14 +1,26 @@
-﻿using System.Linq;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Controls;
 using NUnit.Framework;
 using Dynamo.Selection;
 using System.IO;
+using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Nodes.ZeroTouch;
 using Dynamo.Graph.Workspaces;
+using Dynamo.Models;
+using Dynamo.Views;
 
 namespace Dynamo.Tests
 {
     public class WorkspaceGeneralOperations : DynamoViewModelUnitTest
     {
+        protected override void GetLibrariesToPreload(List<string> libraries)
+        {
+            libraries.Add("VMDataBridge.dll");  // Required for reading preview bubble data
+            base.GetLibrariesToPreload(libraries);
+        }
+
         [Test]
         public void SwitchingToCustomWorkspaceWithSelectionShouldNotAllowGeometricOperations()
         {
@@ -39,6 +51,80 @@ namespace Dynamo.Tests
             // disabled despite the fact that there is still selection.
             Assert.AreEqual(true, ViewModel.CurrentSpaceViewModel.HasSelection);
             Assert.AreEqual(false, ViewModel.CurrentSpaceViewModel.IsGeometryOperationEnabled);
+        }
+
+        [Test]
+        public void VerifyGlobalLacingStrategyUpdatesForLacingStrategies()
+        {
+            var openPath = Path.Combine(TestDirectory, @"core\visualization\LacingStrategyGlobal.dyn");
+            ViewModel.OpenCommand.Execute(openPath);
+
+            var workspace = ViewModel.Model.CurrentWorkspace as HomeWorkspaceModel;
+            workspace.RunSettings.RunType = RunType.Automatic;
+
+            // Identifiers for all nodes in the workspace.
+            var nodeIds = new[]
+            {
+                Guid.Parse("0750d269-26f3-47d7-bb25-79c762a540ff"), // point0
+                Guid.Parse("33b03fa4-50e7-4d08-a5d8-ae7f168c2624"), // point1
+                Guid.Parse("fa226a63-1a31-4f13-8b93-1286dac2c695"), // point2
+                Guid.Parse("e7b0f340-a0bc-46b2-a05d-7dd71c72e27c"), // arrays codeblock [1..5] and [11..12]
+            };
+
+            // Verify node state in workspace
+            var nodes = nodeIds.Select(workspace.NodeFromWorkspace).ToList();
+            Assert.IsFalse(nodes.Any(n => n == null)); // Nothing should be null.
+
+            // Verify initial lacing state is Auto and nodes return correct number of points
+            // 5 points for point0 node, 2 points for point1 and point2 nodes
+            AssertPreviewCount(nodeIds[0].ToString(), 5);
+            AssertPreviewCount(nodeIds[1].ToString(), 2);
+            AssertPreviewCount(nodeIds[2].ToString(), 2);
+
+            // Modify lacing strategy to Longest
+            ViewModel.CurrentSpaceViewModel.SelectAllCommand.Execute(null);
+            ViewModel.CurrentSpaceViewModel.SetArgumentLacingCommand.Execute(LacingStrategy.Longest.ToString());
+
+            AssertPreviewCount(nodeIds[0].ToString(), 5);
+            AssertPreviewCount(nodeIds[1].ToString(), 2);
+            AssertPreviewCount(nodeIds[2].ToString(), 5);
+
+            // Modify lacing strategy to Auto
+            ViewModel.CurrentSpaceViewModel.SelectAllCommand.Execute(null);
+            ViewModel.CurrentSpaceViewModel.SetArgumentLacingCommand.Execute(LacingStrategy.Auto.ToString());
+
+            AssertPreviewCount(nodeIds[0].ToString(), 5);
+            AssertPreviewCount(nodeIds[1].ToString(), 2);
+            AssertPreviewCount(nodeIds[2].ToString(), 2);
+
+            // Modify lacing strategy to CrossProduct
+            ViewModel.CurrentSpaceViewModel.SelectAllCommand.Execute(null);
+            ViewModel.CurrentSpaceViewModel.SetArgumentLacingCommand.Execute(LacingStrategy.CrossProduct.ToString());
+
+            AssertPreviewCount(nodeIds[0].ToString(), 5);
+            AssertPreviewCount(nodeIds[1].ToString(), 2);
+            AssertPreviewCount(nodeIds[2].ToString(), 5);
+
+            // Change lacing back to Shortest
+            ViewModel.CurrentSpaceViewModel.SelectAllCommand.Execute(null);
+            ViewModel.CurrentSpaceViewModel.SetArgumentLacingCommand.Execute(LacingStrategy.Shortest.ToString());
+
+            AssertPreviewCount(nodeIds[0].ToString(), 5);
+            AssertPreviewCount(nodeIds[1].ToString(), 2);
+            AssertPreviewCount(nodeIds[2].ToString(), 2);
+        }
+
+        [Test]
+        public void AreGlobalLacingStrategiesInMenu()
+        {
+            // Mock a WorkspaceView
+            var workspaceView = new WorkspaceView();
+
+            // Search the associated context menu for the lacing sub-menu
+            var contextMenu = workspaceView.FindName("WorkspaceLacingMenu") as MenuItem;
+
+            // Auto, Shortest, Longest, Cross Product
+            Assert.AreEqual(contextMenu.Items.Count, 4);
         }
     }
 }


### PR DESCRIPTION
### Purpose

[DYN-1710](https://jira.autodesk.com/browse/DYN-1710)

This PR adds testing coverage to another open PR #9572 which has not yet been merged.  I have already reviewed @RyaPorter 's work which looks good.  Once this PR is reviewed it can be merged into #9572 followed by #9572 being merged into master.

### Testing
This functionality is currently partially covered in `HelixWatch3DViewModelTests.cs` which are `VisualizationTests`.  Unfortunately, these don't yet run in the automated pipeline so I modified the logic into a unit test that will be run in the pipeline.  These tests confirm the appropriate command methods are called for each lacing operation.  The final test verifies all 4 lacing options appear in the context menu.

### Declarations

Check these if you believe they are true

- [x] The code base is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions), and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@RyaPorter 

### FYIs

@QilongTang @mjkkirschner
